### PR TITLE
Upgrade Action Dependencies to node16 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     name: Test upload-tartifact GHA
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initial Tartifact
         uses: alehechka/upload-tartifact@main
@@ -29,10 +29,10 @@ jobs:
     needs: test-upload-tartifact
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Download Test Artifact
-        uses: alehechka/download-tartifact@main
+        uses: ./
         with:
           name: test
           path: test
@@ -42,7 +42,7 @@ jobs:
         working-directory: test
 
       - name: Download Test2 Artifact
-        uses: alehechka/download-tartifact@main
+        uses: ./
         with:
           name: test2
           path: test2

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}


### PR DESCRIPTION
# Overview
Upgraded all Action Dependencies to use node16 versions to avoid deprecation cutoff.