### PR TITLE
Bump to `download-artifact@v4`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}


### PR DESCRIPTION
New version of [`download-artifact`](download-artifact@v4) has been released, and I was wondering if we can have a new version of `alehechka/download-tartifact` that uses the latest version of `download-artifact`.

We faced a problem in https://github.com/fastify/website/issues/176, since we were using `upload-artifact@v4.0`, which is not compatible with `download-artifact@v3`.